### PR TITLE
Add min width attribute for VerticalMode

### DIFF
--- a/chip-navigation-bar/src/main/java/com/ismaeldivita/chipnavigation/ChipNavigationBar.kt
+++ b/chip-navigation-bar/src/main/java/com/ismaeldivita/chipnavigation/ChipNavigationBar.kt
@@ -14,7 +14,6 @@ import com.ismaeldivita.chipnavigation.util.applyWindowInsets
 import com.ismaeldivita.chipnavigation.util.forEachChild
 import com.ismaeldivita.chipnavigation.view.MenuItemView
 import com.ismaeldivita.chipnavigation.view.VerticalMenuItemView
-import java.lang.IllegalArgumentException
 
 class ChipNavigationBar @JvmOverloads constructor(
     context: Context,
@@ -24,12 +23,14 @@ class ChipNavigationBar @JvmOverloads constructor(
     private lateinit var orientationMode: MenuOrientation
     private val behavior: HideOnScrollBehavior
     private var listener: OnItemSelectedListener? = null
+    private var minimumExpandedWidth: Int = 0
 
     init {
         val a = context.obtainStyledAttributes(attrs, R.styleable.ChipNavigationBar)
 
         val menuResource = a.getResourceId(R.styleable.ChipNavigationBar_cnb_menuResource, -1)
         val hideOnScroll = a.getBoolean(R.styleable.ChipNavigationBar_cnb_hideOnScroll, false)
+        val minExpanded = a.getDimension(R.styleable.ChipNavigationBar_cnb_minExpandedWidth, 0F)
         val leftInset = a.getBoolean(R.styleable.ChipNavigationBar_cnb_addLeftInset, false)
         val topInset = a.getBoolean(R.styleable.ChipNavigationBar_cnb_addTopInset, false)
         val rightInset = a.getBoolean(R.styleable.ChipNavigationBar_cnb_addRightInset, false)
@@ -37,7 +38,7 @@ class ChipNavigationBar @JvmOverloads constructor(
         val orientation = when (a.getInt(R.styleable.ChipNavigationBar_cnb_orientationMode, 0)) {
             0 -> MenuOrientation.HORIZONTAL
             1 -> MenuOrientation.VERTICAL
-            else -> throw IllegalArgumentException()
+            else -> MenuOrientation.HORIZONTAL
         }
 
         a.recycle()
@@ -49,8 +50,10 @@ class ChipNavigationBar @JvmOverloads constructor(
             setMenuResource(menuResource)
         }
 
+        setMinimumExpandedWidth(minExpanded.toInt())
         setHideOnScroll(hideOnScroll)
         applyWindowInsets(leftInset, topInset, rightInset, bottomInset)
+        collapse()
 
         isClickable = true
     }
@@ -131,6 +134,15 @@ class ChipNavigationBar @JvmOverloads constructor(
     }
 
     /**
+     * Set the minimum width for the vertical expanded state.
+     *
+     * @param minExpandedWidth width in pixels
+     */
+    fun setMinimumExpandedWidth(minExpandedWidth: Int) {
+        minimumExpandedWidth = minExpandedWidth
+    }
+
+    /**
      * Set the duration of the enter animation for the hide on scroll [CoordinatorLayout.Behavior]
      * Default value [HideOnScrollBehavior.DEFAULT_ENTER_DURATION]
      * The behavior is only active when orientation orientationMode is HORIZONTAL
@@ -198,6 +210,7 @@ class ChipNavigationBar @JvmOverloads constructor(
     fun collapse() {
         if (orientationMode == MenuOrientation.VERTICAL) {
             forEachChild {
+                it.minimumWidth = 0
                 (it as? VerticalMenuItemView)?.collapse()
             }
         }
@@ -209,6 +222,7 @@ class ChipNavigationBar @JvmOverloads constructor(
     fun expand() {
         if (orientationMode == MenuOrientation.VERTICAL) {
             forEachChild {
+                it.minimumWidth = minimumExpandedWidth
                 (it as? VerticalMenuItemView)?.expand()
             }
         }

--- a/chip-navigation-bar/src/main/res/values/attrs.xml
+++ b/chip-navigation-bar/src/main/res/values/attrs.xml
@@ -4,6 +4,7 @@
     <declare-styleable name="ChipNavigationBar">
         <attr name="cnb_menuResource" format="reference" />
         <attr name="cnb_hideOnScroll" format="boolean" />
+        <attr name="cnb_minExpandedWidth" format="dimension" />
         <attr name="cnb_addBottomInset" format="boolean" />
         <attr name="cnb_addTopInset" format="boolean" />
         <attr name="cnb_addLeftInset" format="boolean" />

--- a/sample/src/main/java/com/ismaeldivita/chipnavigation/sample/VerticalModeActivity.kt
+++ b/sample/src/main/java/com/ismaeldivita/chipnavigation/sample/VerticalModeActivity.kt
@@ -20,7 +20,7 @@ class VerticalModeActivity : AppCompatActivity() {
     private val menu by lazy { findViewById<ChipNavigationBar>(R.id.bottom_menu) }
 
     private var lastColor: Int = 0
-    private var isExpanded = true
+    private var isExpanded = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/sample/src/main/res/layout/activity_vertical.xml
+++ b/sample/src/main/res/layout/activity_vertical.xml
@@ -22,6 +22,7 @@
             android:layout_height="0dp"
             android:layout_weight="1"
             android:elevation="16dp"
+            app:cnb_minExpandedWidth="200dp"
             app:cnb_addTopInset="true"
             app:cnb_menuResource="@menu/test"
             app:cnb_orientationMode="vertical" />


### PR DESCRIPTION
Add `cnb_minExpandedWidth` attribute for VerticalMode to make possible control the size when expanded.

<img src="https://user-images.githubusercontent.com/7879502/62902043-43922880-bd56-11e9-83e3-d41755836a44.png" width="470"/>

<img src="https://user-images.githubusercontent.com/7879502/62902085-5d337000-bd56-11e9-88ad-688544957c9e.png" width="470"/>


