### PR TITLE
Expose menu

### DIFF
--- a/chip-navigation-bar/.gitignore
+++ b/chip-navigation-bar/.gitignore
@@ -1,1 +1,3 @@
 /build
+/.idea
+local.properties

--- a/chip-navigation-bar/build.gradle
+++ b/chip-navigation-bar/build.gradle
@@ -10,7 +10,7 @@ android {
 
 
     defaultConfig {
-        minSdkVersion 22
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/chip-navigation-bar/src/main/java/com/ismaeldivita/chipnavigation/ChipNavigationBar.kt
+++ b/chip-navigation-bar/src/main/java/com/ismaeldivita/chipnavigation/ChipNavigationBar.kt
@@ -2,18 +2,18 @@ package com.ismaeldivita.chipnavigation
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.View
 import android.widget.LinearLayout
+import androidx.annotation.IntRange
 import androidx.annotation.MenuRes
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import com.ismaeldivita.chipnavigation.behavior.HideOnScrollBehavior
+import com.ismaeldivita.chipnavigation.model.Menu
 import com.ismaeldivita.chipnavigation.model.MenuParser
-import com.ismaeldivita.chipnavigation.util.getChildren
-import com.ismaeldivita.chipnavigation.view.HorizontalMenuItemView
-import android.view.View
-import androidx.annotation.IntDef
-import androidx.annotation.IntRange
 import com.ismaeldivita.chipnavigation.util.applyWindowInsets
 import com.ismaeldivita.chipnavigation.util.forEachChild
+import com.ismaeldivita.chipnavigation.util.getChildren
+import com.ismaeldivita.chipnavigation.view.HorizontalMenuItemView
 import com.ismaeldivita.chipnavigation.view.MenuItemView
 import com.ismaeldivita.chipnavigation.view.VerticalMenuItemView
 
@@ -26,6 +26,8 @@ class ChipNavigationBar @JvmOverloads constructor(
     private val behavior: HideOnScrollBehavior
     private var listener: OnItemSelectedListener? = null
     private var minimumExpandedWidth: Int = 0
+
+    var menu: Menu? = null
 
     init {
         val a = context.obtainStyledAttributes(attrs, R.styleable.ChipNavigationBar)
@@ -66,7 +68,7 @@ class ChipNavigationBar @JvmOverloads constructor(
      * @param menuRes Resource ID for an XML layout resource to load
      */
     fun setMenuResource(@MenuRes menuRes: Int) {
-        val menu = (MenuParser(context).parse(menuRes))
+        menu = (MenuParser(context).parse(menuRes))
         val childListener: (View) -> Unit = { view ->
             val id = view.id
             setItemSelected(id)
@@ -75,7 +77,7 @@ class ChipNavigationBar @JvmOverloads constructor(
 
         removeAllViews()
 
-        menu.items.forEach {
+        menu?.items?.forEach {
             val itemView = createMenuItem().apply {
                 bind(it)
                 setOnClickListener(childListener)

--- a/chip-navigation-bar/src/main/java/com/ismaeldivita/chipnavigation/model/Menu.kt
+++ b/chip-navigation-bar/src/main/java/com/ismaeldivita/chipnavigation/model/Menu.kt
@@ -2,7 +2,7 @@ package com.ismaeldivita.chipnavigation.model
 
 import androidx.annotation.ColorInt
 
-internal data class Menu(
+data class Menu(
     val items: List<MenuItem>,
     @ColorInt val badgeColor: Int,
     @ColorInt val disabledColor: Int,

--- a/chip-navigation-bar/src/main/java/com/ismaeldivita/chipnavigation/model/MenuItem.kt
+++ b/chip-navigation-bar/src/main/java/com/ismaeldivita/chipnavigation/model/MenuItem.kt
@@ -4,7 +4,7 @@ import android.graphics.PorterDuff
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 
-internal data class MenuItem(
+data class MenuItem(
     val id: Int,
     val title: CharSequence,
     @DrawableRes val icon: Int,


### PR DESCRIPTION
Menu has to be exposed for correct integration with navigation.

For example, now you can use this code for correct bottom nav switching on fragment change in AndroidX navigation:

```
internal fun matchDestination(destination: NavDestination, @IdRes destId: Int): Boolean {
    var currentDestination: NavDestination
    currentDestination = destination

    while (currentDestination.id != destId && currentDestination.parent != null) {
        currentDestination = currentDestination.parent as NavDestination
    }

    return currentDestination.id == destId
}

fun setupWithNavController(
    bottomNavigationView: ChipNavigationBar,
    navController: NavController
) {
    var selectedItemId = -1

    bottomNavigationView.setOnItemSelectedListener { itemId ->
        if (itemId != selectedItemId) {
            navController.navigate(itemId, null, null)
        }
    }

    val weakReference = WeakReference(bottomNavigationView)

    navController.addOnDestinationChangedListener(object :
        NavController.OnDestinationChangedListener {
        override fun onDestinationChanged(
            controller: NavController,
            destination: NavDestination,
            arguments: Bundle?
        ) {
            val view = weakReference.get()
            if (view == null) {
                navController.removeOnDestinationChangedListener(this)
            } else {
                view.menu?.let { menu ->
                    var h = 0

                    val size = menu.items.size
                    while (h < size) {
                        val item = menu.items[h]
                        if (matchDestination(destination, item.id)) {
                            view.setItemSelected(item.id)
                            selectedItemId = item.id
                        }

                        ++h
                    }
                }
            }
        }
    })
}
```

Note: menu items' ids must match navigation fragment ids.