### PR TITLE
Fix cnb_textColor attribute not affected in horizontal orientation

### DIFF
--- a/chip-navigation-bar/src/main/java/com/ismaeldivita/chipnavigation/view/HorizontalMenuItemView.kt
+++ b/chip-navigation-bar/src/main/java/com/ismaeldivita/chipnavigation/view/HorizontalMenuItemView.kt
@@ -43,7 +43,7 @@ internal class HorizontalMenuItemView @JvmOverloads constructor(
         title.text = item.title
         title.setTextColor(item.textColor)
         title.setColorStateListAnimator(
-            color = item.iconColor,
+            color = item.textColor,
             unselectedColor = item.menuStyle.unselectedColor
         )
 


### PR DESCRIPTION
As the title described, the cnb_textColor is not working in horizontal orientation. 
The label color is always override by iconColor or the default color. 
So I change the title color from `item.iconColor` to `item.textColor` in `HorizontalMenuItemView`.